### PR TITLE
refactor: Update runpod dependency to >= versioning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ray
 pandas
 pyarrow
-runpod~=1.7.0
+runpod>=1.8.0
 pydantic-settings


### PR DESCRIPTION
Changes:
- Update runpod from ~=1.7.0 to >=1.8.0
- Aligns with new versioning strategy across all worker repos

The >= operator allows any version greater than or equal to 1.8.0, replacing the ~= (compatible release) constraint that only allowed patch updates within the same major.minor version.