### PR TITLE
fix(handler): return error response when SGLang requests fail with non-200 status

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -39,6 +39,9 @@ async def async_handler(job):
         headers = {"Content-Type": "application/json"}
 
         response = requests.post(openai_url, headers=headers, json=openai_input)
+        if response.status_code != 200:
+            yield {"error": f"Request failed with status code {response.status_code}", "details": response.text}
+            return
         # Process the streamed response
         if openai_input.get("stream", False):
             for formated_chunk in process_response(response):
@@ -59,7 +62,9 @@ async def async_handler(job):
             job_input["model"] = engine.model or "default"
 
         response = requests.post(openai_url, headers=headers, json=job_input)
-
+        if response.status_code != 200:
+            yield {"error": f"Request failed with status code {response.status_code}", "details": response.text}
+            return
         if job_input.get("stream", False):
             for formated_chunk in process_response(response):
                 yield formated_chunk


### PR DESCRIPTION
## Summary

`async_handler` has three request paths (explicit OpenAI route, chat/completions
shorthand, and native `/generate`). Case 3 guards against non-200 responses before
yielding; Cases 1 and 2 do not, passing whatever SGLang returns directly into
`process_response` or `iter_lines`.

In failure scenarios — misconfigured `MODEL_NAME`, OOM crashes, unsupported
parameters — this causes SGLang's error payload to be streamed back as valid
response chunks. The caller receives no `error` key and no status indication,
making the failure mode indistinguishable from legitimate model output at the
application layer.

## Changes

Added the same `status_code` guard to Cases 1 and 2 that Case 3 already employs.
Error messages are intentionally scoped per route (`"Request failed..."` for OpenAI
routes vs `"Generate request failed..."` for `/generate`) to preserve endpoint
context in the error response.

## Testing

- `docker build --platform linux/amd64 -t worker-sglang-test .` passes
- Syntax validated inside the built container
- Reproduced failure mode by simulating non-200 responses — confirmed raw error
  payload is surfaced as model output without the guard, and correctly returned
  as a structured error with it
